### PR TITLE
add handler for docker splunk logging driver

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -35,3 +35,27 @@ linters-settings:
       - .Wrap(
       - .WithCode(
       - .ValidateStruct(
+
+  varnamelen:
+    # The longest distance, in source lines, that is being considered a "small scope." (defaults to 5)
+    # Variables used in at most this many lines will be ignored.
+    max-distance: 10
+    # Ignore "ok" variables that hold the bool return value of a type assertion. (defaults to false)
+    ignore-type-assert-ok: true
+    # Ignore "ok" variables that hold the bool return value of a map index. (defaults to false)
+    ignore-map-index-ok: true
+    # Ignore "ok" variables that hold the bool return value of a channel receive. (defaults to false)
+    ignore-chan-recv-ok: true
+    # Optional list of variable names that should be ignored completely. (defaults to empty list)
+    ignore-names:
+      - ch
+      - db
+      - ip
+    # Optional list of variable declarations that should be ignored completely. (defaults to empty list)
+    # Entries must be in the form of "<variable name> <type>" or "<variable name> *<type>" for
+    # variables, or "const <name>" for constants.
+    ignore-decls:
+      - w http.ResponseWriter
+      - r *http.Request
+      - t testing.T
+      - tx *sqlx.Tx

--- a/README.md
+++ b/README.md
@@ -1,5 +1,19 @@
 # Collector
 
+## Use docker-compose logging driver.
+
+```yaml
+services:
+  vuewer:
+    image: service:latest
+    logging:
+      driver: "splunk"
+      options:
+        splunk-token: "SECRET_TOKEN"
+        splunk-url: "https://collector-host.com:8080"
+        splunk-format: "json"
+```
+
 ## Configuration
 
 #### ENV:
@@ -66,7 +80,10 @@ SERVICE_AUTH_TOKENS=secret_token_1 secret_token_2
     },
     "auth": {
       "enable": true,
-      "tokens": ["secret_token_1", "secret_token_2"]
+      "tokens": [
+        "secret_token_1",
+        "secret_token_2"
+      ]
     }
   }
 }

--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -8,15 +8,15 @@ services:
       - 127.0.0.1:8123:8123
       - 127.0.0.1:9500:9000
       - 127.0.0.1:9009:9009
-
-  jaeger:
-    image: jaegertracing/all-in-one:1.19
-    ports:
-      - "6831:6831/udp"
-      - "16686:16686"
+#
+#  jaeger:
+#    image: jaegertracing/all-in-one:1.19
+#    ports:
+#      - "6831:6831/udp"
+#      - "16686:16686"
 
   collector:
-    image: golang:1.15-alpine
+    image: golang:1.17-alpine
     volumes:
       - ./:/app
     working_dir: /app/cmd/collector/
@@ -26,8 +26,8 @@ services:
       - SERVER_CERT=
       - SERVER_KEY=
 
-      - ENABLE_AUTH=true
-      - TOKEN_LIST=secret_token_1 secret_token_2
+      - SERVICE_AUTH_ENABLE=true
+      - SERVICE_AUTH_TOKENS=secret_token_1 secret_token_2
 
       - LOGGER_LEVEL=debug
 
@@ -40,4 +40,4 @@ services:
       - 50000:8080
     depends_on:
       - clickhouse-db
-      - jaeger
+#      - jaeger

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/loghole/collector
 
-go 1.16
+go 1.17
 
 require (
 	github.com/ClickHouse/clickhouse-go v1.4.5
@@ -17,4 +17,46 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/uber/jaeger-client-go v2.29.1+incompatible
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+)
+
+require (
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/cloudflare/golz4 v0.0.0-20150217214814-ef862a3cdc58 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/json-iterator/go v1.1.11 // indirect
+	github.com/lib/pq v1.10.2 // indirect
+	github.com/loghole/dbhook v0.3.0 // indirect
+	github.com/magiconair/properties v1.8.5 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/mitchellh/mapstructure v1.4.1 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
+	github.com/opentracing-contrib/go-stdlib v1.0.0 // indirect
+	github.com/opentracing/opentracing-go v1.2.0 // indirect
+	github.com/pelletier/go-toml v1.9.3 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/prometheus/client_golang v1.11.0 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/common v0.26.0 // indirect
+	github.com/prometheus/procfs v0.6.0 // indirect
+	github.com/spf13/afero v1.6.0 // indirect
+	github.com/spf13/cast v1.3.1 // indirect
+	github.com/spf13/jwalterweatherman v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/subosito/gotenv v1.2.0 // indirect
+	github.com/uber/jaeger-lib v2.4.1+incompatible // indirect
+	go.uber.org/atomic v1.7.0 // indirect
+	go.uber.org/multierr v1.6.0 // indirect
+	go.uber.org/zap v1.18.1 // indirect
+	golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40 // indirect
+	golang.org/x/text v0.3.6 // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
+	gopkg.in/ini.v1 v1.62.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/internal/app/api/entry/v1/handlers_entry.go
+++ b/internal/app/api/entry/v1/handlers_entry.go
@@ -1,9 +1,8 @@
-package handlers
+package v1
 
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/lissteron/simplerr"
@@ -11,7 +10,6 @@ import (
 	"github.com/loghole/tracing/tracelog"
 
 	"github.com/loghole/collector/internal/app/codes"
-	"github.com/loghole/collector/internal/app/controllers/http/response"
 )
 
 type EntryService interface {
@@ -39,7 +37,7 @@ func NewEntryHandlers(
 }
 
 func (h *EntryHandlers) StoreItemHandler(w http.ResponseWriter, r *http.Request) {
-	resp, ctx := response.NewBaseResponse(), r.Context()
+	resp, ctx := NewBaseResponse(), r.Context()
 	defer resp.Write(ctx, w, h.logger)
 
 	data, err := readData(r.Body)
@@ -58,7 +56,7 @@ func (h *EntryHandlers) StoreItemHandler(w http.ResponseWriter, r *http.Request)
 }
 
 func (h *EntryHandlers) StoreListHandler(w http.ResponseWriter, r *http.Request) {
-	resp, ctx := response.NewBaseResponse(), r.Context()
+	resp, ctx := NewBaseResponse(), r.Context()
 	defer resp.Write(ctx, w, h.logger)
 
 	data, err := readData(r.Body)
@@ -77,7 +75,7 @@ func (h *EntryHandlers) StoreListHandler(w http.ResponseWriter, r *http.Request)
 }
 
 func (h *EntryHandlers) PingHandler(w http.ResponseWriter, r *http.Request) {
-	resp, ctx := response.NewBaseResponse(), r.Context()
+	resp, ctx := NewBaseResponse(), r.Context()
 	defer resp.Write(ctx, w, h.logger)
 
 	if err := h.service.Ping(ctx); err != nil {
@@ -87,7 +85,7 @@ func (h *EntryHandlers) PingHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func readData(r io.Reader) ([]byte, error) {
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		return nil, simplerr.WrapWithCode(err, simplerr.InternalCode(codes.SystemError), "system error")
 	}

--- a/internal/app/api/entry/v1/handlers_info.go
+++ b/internal/app/api/entry/v1/handlers_info.go
@@ -1,4 +1,4 @@
-package handlers
+package v1
 
 import (
 	"net/http"
@@ -6,7 +6,6 @@ import (
 	"github.com/loghole/tracing/tracelog"
 
 	"github.com/loghole/collector/config"
-	"github.com/loghole/collector/internal/app/controllers/http/response"
 )
 
 type info struct {
@@ -36,7 +35,7 @@ func NewInfoHandlers(logger tracelog.Logger) *InfoHandlers {
 }
 
 func (h *InfoHandlers) InfoHandler(w http.ResponseWriter, r *http.Request) {
-	resp, ctx := response.NewBaseResponse(), r.Context()
+	resp, ctx := NewBaseResponse(), r.Context()
 	defer resp.Write(ctx, w, h.logger)
 
 	resp.SetData(h.info)

--- a/internal/app/api/entry/v1/response.go
+++ b/internal/app/api/entry/v1/response.go
@@ -1,4 +1,4 @@
-package response
+package v1
 
 import (
 	"context"

--- a/internal/app/api/middleware/middleware_remote_ip.go
+++ b/internal/app/api/middleware/middleware_remote_ip.go
@@ -1,4 +1,4 @@
-package handlers
+package middleware
 
 import (
 	"net"

--- a/internal/app/api/splunk/v1/handler.go
+++ b/internal/app/api/splunk/v1/handler.go
@@ -1,0 +1,103 @@
+package v1
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/loghole/tracing"
+	"github.com/loghole/tracing/tracelog"
+)
+
+type EntryService interface {
+	StoreItem(ctx context.Context, remoteIP string, data []byte) (err error)
+	StoreList(ctx context.Context, remoteIP string, data []byte) (err error)
+}
+
+type Message struct {
+	Event Event `json:"event"`
+}
+
+type Event struct {
+	Line json.RawMessage `json:"line"`
+}
+
+type SplunkHandler struct {
+	service EntryService
+	logger  tracelog.Logger
+	tracer  *tracing.Tracer
+}
+
+func NewSplunkHandler(
+	service EntryService,
+	logger tracelog.Logger,
+	tracer *tracing.Tracer,
+) *SplunkHandler {
+	return &SplunkHandler{
+		service: service,
+		logger:  logger,
+		tracer:  tracer,
+	}
+}
+
+func (h *SplunkHandler) Handler(w http.ResponseWriter, r *http.Request) {
+	data, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "read data", http.StatusInternalServerError)
+
+		return
+	}
+
+	if len(data) == 0 {
+		return
+	}
+
+	var (
+		ctx  = r.Context()
+		addr = r.RemoteAddr
+	)
+
+	for {
+		idx := bytes.Index(data, []byte("}{"))
+		if idx == -1 {
+			break
+		}
+
+		if err := h.handleMessage(ctx, addr, data[:idx+1]); err != nil {
+			http.Error(w, "handle message", http.StatusInternalServerError)
+
+			return
+		}
+
+		data = data[idx+1:]
+	}
+
+	if err := h.handleMessage(ctx, addr, data); err != nil {
+		http.Error(w, "handle message", http.StatusInternalServerError)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func (h *SplunkHandler) handleMessage(ctx context.Context, addr string, data []byte) error {
+	var dest Message
+
+	if err := json.Unmarshal(data, &dest); err != nil {
+		h.logger.Errorf(ctx, "unmarshal message: %v", err)
+
+		return nil
+	}
+
+	if err := h.service.StoreItem(ctx, addr, dest.Event.Line); err != nil {
+		h.logger.Errorf(ctx, "store item: %v", err)
+
+		return fmt.Errorf("store item: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Added support for splunk logging driver.

Example docker-compose configuration:

```yaml
services:
  vuewer:
    image: service:latest
    logging:
      driver: "splunk"
      options:
        splunk-token: "SECRET_TOKEN"
        splunk-url: "https://collector-host.com:8080"
        splunk-format: "json"
```